### PR TITLE
Updates

### DIFF
--- a/Converter.hh
+++ b/Converter.hh
@@ -25,7 +25,10 @@ public:
 
 private:
     bool AboveThreshold(double, int);
+    bool InsideTimeWindow();
+
     // GRIFFIN
+    void CheckGriffinCrystalAddback();
     void SupressGriffin();
     void SupressGriffinByNeighbouringAncillaryBgos();
     void SupressGriffinBySceptar();
@@ -33,18 +36,26 @@ private:
     void AddbackGriffinNeighbour();
     void AddbackGriffinNeighbourVector();
     // LaBr
+    void CheckLaBrDetectorAddback();
     void SupressLaBr();
     void SupressLaBrByNeighbouringGriffinShields();
     void AddbackLaBr();
     // EightPi
+    void CheckEightPiDetectorAddback();
     void SupressEightPi();
     void AddbackEightPi();
     // Ancillary BGO
+    void CheckAncillaryBgoCrystalAddback();
     void AddbackAncillaryBgo();
     // SCEPTAR
+    void CheckSceptarDetectorAddback();
     void AddbackSceptar();
     // DESCANT
+    void CheckDescantDetectorAddback();
     void AddbackDescant();
+    // Paces
+    void CheckPacesDetectorAddback();
+    void AddbackPaces();
 
     void PrintStatistics();
 
@@ -149,6 +160,10 @@ private:
     std::vector<Detector>* fDescantRedDetector;
     std::vector<Detector>* fDescantWhiteDetector;
     std::vector<Detector>* fDescantYellowDetector;
+
+    // Paces
+    std::vector<Detector>* fPacesArray;
+    std::vector<Detector>* fPacesDetector;
 
     //histograms
     std::map<std::string,TList*> fHistograms;

--- a/Griffin.hh
+++ b/Griffin.hh
@@ -24,6 +24,9 @@ public:
         fPosition = pos;
         fTime = time;
     }
+    void SetTime(double time) {
+        fTime = time;
+    }
     void Clear() {
         fEventNumber = -1;
         fDetectorId = 0;

--- a/Settings.cc
+++ b/Settings.cc
@@ -10,6 +10,8 @@ Settings::Settings(std::string fileName, int verbosityLevel)
 
     //  env.PrintEnv();
 
+    fNtupleName = env.GetValue("NtupleName","/ntuple/ntuple");
+
     fBufferSize = env.GetValue("BufferSize",1024000);
 
     fSortNumberOfEvents = env.GetValue("SortNumberOfEvents",0);
@@ -34,69 +36,97 @@ Settings::Settings(std::string fileName, int verbosityLevel)
     fResolution[1000].resize(16);
     fThreshold[1000].resize(16,std::vector<double>(4));
     fThresholdWidth[1000].resize(16,std::vector<double>(4));
+    fTimeWindow[1000].resize(16,std::vector<double>(4));
 
     fResolution[1010].resize(16);
     fThreshold[1010].resize(16,std::vector<double>(4));
     fThresholdWidth[1010].resize(16,std::vector<double>(4));
+    fTimeWindow[1010].resize(16,std::vector<double>(4));
 
     fResolution[1020].resize(16);
     fThreshold[1020].resize(16,std::vector<double>(4));
     fThresholdWidth[1020].resize(16,std::vector<double>(4));
+    fTimeWindow[1020].resize(16,std::vector<double>(4));
 
     fResolution[1030].resize(16);
     fThreshold[1030].resize(16,std::vector<double>(4));
     fThresholdWidth[1030].resize(16,std::vector<double>(4));
+    fTimeWindow[1030].resize(16,std::vector<double>(4));
 
     fResolution[1040].resize(16);
     fThreshold[1040].resize(16,std::vector<double>(4));
     fThresholdWidth[1040].resize(16,std::vector<double>(4));
+    fTimeWindow[1040].resize(16,std::vector<double>(4));
 
     fResolution[1050].resize(16);
     fThreshold[1050].resize(16,std::vector<double>(4));
     fThresholdWidth[1050].resize(16,std::vector<double>(4));
+    fTimeWindow[1050].resize(16,std::vector<double>(4));
 
     // LaBr3
     fResolution[2000].resize(16);
     fThreshold[2000].resize(16,std::vector<double>(1));
     fThresholdWidth[2000].resize(16,std::vector<double>(1));
+    fTimeWindow[2000].resize(16,std::vector<double>(1));
+
+    // Sceptar
+    fResolution[5000].resize(20);
+    fThreshold[5000].resize(20,std::vector<double>(1));
+    fThresholdWidth[5000].resize(20,std::vector<double>(1));
+    fTimeWindow[5000].resize(20,std::vector<double>(1));
 
     // EightPi
     fResolution[6000].resize(20);
     fThreshold[6000].resize(20,std::vector<double>(4));
     fThresholdWidth[6000].resize(20,std::vector<double>(4));
+    fTimeWindow[6000].resize(20,std::vector<double>(4));
 
     fResolution[6010].resize(20);
     fThreshold[6010].resize(20,std::vector<double>(4));
     fThresholdWidth[6010].resize(20,std::vector<double>(4));
+    fTimeWindow[6010].resize(20,std::vector<double>(4));
 
     fResolution[6020].resize(20);
     fThreshold[6020].resize(20,std::vector<double>(4));
     fThresholdWidth[6020].resize(20,std::vector<double>(4));
+    fTimeWindow[6020].resize(20,std::vector<double>(4));
 
     fResolution[6030].resize(20);
     fThreshold[6030].resize(20,std::vector<double>(4));
     fThresholdWidth[6030].resize(20,std::vector<double>(4));
+    fTimeWindow[6030].resize(20,std::vector<double>(4));
 
     // Descant
     fResolution[8010].resize(15);
-    fThreshold[8010].resize(15,std::vector<double>(4));
-    fThresholdWidth[8010].resize(15,std::vector<double>(4));
+    fThreshold[8010].resize(15,std::vector<double>(1));
+    fThresholdWidth[8010].resize(15,std::vector<double>(1));
+    fTimeWindow[8010].resize(15,std::vector<double>(1));
 
     fResolution[8020].resize(10);
-    fThreshold[8020].resize(10,std::vector<double>(4));
-    fThresholdWidth[8020].resize(10,std::vector<double>(4));
+    fThreshold[8020].resize(10,std::vector<double>(1));
+    fThresholdWidth[8020].resize(10,std::vector<double>(1));
+    fTimeWindow[8020].resize(10,std::vector<double>(1));
 
     fResolution[8030].resize(15);
-    fThreshold[8030].resize(15,std::vector<double>(4));
-    fThresholdWidth[8030].resize(15,std::vector<double>(4));
+    fThreshold[8030].resize(15,std::vector<double>(1));
+    fThresholdWidth[8030].resize(15,std::vector<double>(1));
+    fTimeWindow[8030].resize(15,std::vector<double>(1));
 
     fResolution[8040].resize(20);
-    fThreshold[8040].resize(20,std::vector<double>(4));
-    fThresholdWidth[8040].resize(20,std::vector<double>(4));
+    fThreshold[8040].resize(20,std::vector<double>(1));
+    fThresholdWidth[8040].resize(20,std::vector<double>(1));
+    fTimeWindow[8040].resize(20,std::vector<double>(1));
 
     fResolution[8050].resize(10);
-    fThreshold[8050].resize(10,std::vector<double>(4));
-    fThresholdWidth[8050].resize(10,std::vector<double>(4));
+    fThreshold[8050].resize(10,std::vector<double>(1));
+    fThresholdWidth[8050].resize(10,std::vector<double>(1));
+    fTimeWindow[8050].resize(10,std::vector<double>(1));
+
+    // Paces
+    fResolution[9000].resize(5);
+    fThreshold[9000].resize(5,std::vector<double>(1));
+    fThresholdWidth[9000].resize(5,std::vector<double>(1));
+    fTimeWindow[9000].resize(5,std::vector<double>(1));
 
     double offset, linear, quadratic, cubic;
 
@@ -111,6 +141,7 @@ Settings::Settings(std::string fileName, int verbosityLevel)
                                                       Form("(TMath::Sqrt((%f+%f*x+%f*x*x+%f*x*x*x)))/(2.*TMath::Sqrt(2.*TMath::Log(2.)))",offset, linear, quadratic, cubic),0.,100000.));
             fThreshold[1000][detector][crystal] = env.GetValue(Form("Griffin.%d.%d.Threshold.keV",detector,crystal),10.);
             fThresholdWidth[1000][detector][crystal] = env.GetValue(Form("Griffin.%d.%d.ThresholdWidth.keV",detector,crystal),2.);
+            fTimeWindow[1000][detector][crystal] = env.GetValue(Form("Griffin.%d.%d.TimeWindow.sec",detector,crystal),0.);
 
             offset = env.GetValue(Form("Griffin.BGO.Front.Left.%d.%d.Resolution.Offset",detector,crystal),1.100);
             linear = env.GetValue(Form("Griffin.BGO.Front.Left.%d.%d.Resolution.Linear",detector,crystal),0.00183744);
@@ -120,6 +151,7 @@ Settings::Settings(std::string fileName, int verbosityLevel)
                                                       Form("(TMath::Sqrt((%f+%f*x+%f*x*x+%f*x*x*x)))/(2.*TMath::Sqrt(2.*TMath::Log(2.)))",offset, linear, quadratic, cubic),0.,100000.));
             fThreshold[1010][detector][crystal] = env.GetValue(Form("Griffin.BGO.Front.Left.%d.%d.Threshold.keV",detector,crystal),10.);
             fThresholdWidth[1010][detector][crystal] = env.GetValue(Form("Griffin.BGO.Front.Left.%d.%d.ThresholdWidth.keV",detector,crystal),2.);
+            fTimeWindow[1010][detector][crystal] = env.GetValue(Form("Griffin.BGO.Front.Left.%d.%d.TimeWindow.sec",detector,crystal),0.);
 
             offset = env.GetValue(Form("Griffin.BGO.Front.Right.%d.%d.Resolution.Offset",detector,crystal),1.100);
             linear = env.GetValue(Form("Griffin.BGO.Front.Right.%d.%d.Resolution.Linear",detector,crystal),0.00183744);
@@ -129,6 +161,7 @@ Settings::Settings(std::string fileName, int verbosityLevel)
                                                       Form("(TMath::Sqrt((%f+%f*x+%f*x*x+%f*x*x*x)))/(2.*TMath::Sqrt(2.*TMath::Log(2.)))",offset, linear, quadratic, cubic),0.,100000.));
             fThreshold[1020][detector][crystal] = env.GetValue(Form("Griffin.BGO.Front.Right.%d.%d.Threshold.keV",detector,crystal),10.);
             fThresholdWidth[1020][detector][crystal] = env.GetValue(Form("Griffin.BGO.Front.Right.%d.%d.ThresholdWidth.keV",detector,crystal),2.);
+            fTimeWindow[1020][detector][crystal] = env.GetValue(Form("Griffin.BGO.Front.Right.%d.%d.TimeWindow.sec",detector,crystal),0.);
 
             offset = env.GetValue(Form("Griffin.BGO.Side.Left.%d.%d.Resolution.Offset",detector,crystal),1.100);
             linear = env.GetValue(Form("Griffin.BGO.Side.Left.%d.%d.Resolution.Linear",detector,crystal),0.00183744);
@@ -138,6 +171,7 @@ Settings::Settings(std::string fileName, int verbosityLevel)
                                                       Form("(TMath::Sqrt((%f+%f*x+%f*x*x+%f*x*x*x)))/(2.*TMath::Sqrt(2.*TMath::Log(2.)))",offset, linear, quadratic, cubic),0.,100000.));
             fThreshold[1030][detector][crystal] = env.GetValue(Form("Griffin.BGO.Side.Left.%d.%d.Threshold.keV",detector,crystal),10.);
             fThresholdWidth[1030][detector][crystal] = env.GetValue(Form("Griffin.BGO.Side.Left.%d.%d.ThresholdWidth.keV",detector,crystal),2.);
+            fTimeWindow[1030][detector][crystal] = env.GetValue(Form("Griffin.BGO.Side.Left.%d.%d.TimeWindow.sec",detector,crystal),0.);
 
             offset = env.GetValue(Form("Griffin.BGO.Side.Right.%d.%d.Resolution.Offset",detector,crystal),1.100);
             linear = env.GetValue(Form("Griffin.BGO.Side.Right.%d.%d.Resolution.Linear",detector,crystal),0.00183744);
@@ -147,6 +181,7 @@ Settings::Settings(std::string fileName, int verbosityLevel)
                                                       Form("(TMath::Sqrt((%f+%f*x+%f*x*x+%f*x*x*x)))/(2.*TMath::Sqrt(2.*TMath::Log(2.)))",offset, linear, quadratic, cubic),0.,100000.));
             fThreshold[1040][detector][crystal] = env.GetValue(Form("Griffin.BGO.Side.Right.%d.%d.Threshold.keV",detector,crystal),10.);
             fThresholdWidth[1040][detector][crystal] = env.GetValue(Form("Griffin.BGO.Side.Right.%d.%d.ThresholdWidth.keV",detector,crystal),2.);
+            fTimeWindow[1040][detector][crystal] = env.GetValue(Form("Griffin.BGO.Side.Right.%d.%d.TimeWindow.sec",detector,crystal),0.);
 
             offset = env.GetValue(Form("Griffin.BGO.Back.%d.%d.Resolution.Offset",detector,crystal),1.100);
             linear = env.GetValue(Form("Griffin.BGO.Back.%d.%d.Resolution.Linear",detector,crystal),0.00183744);
@@ -156,6 +191,7 @@ Settings::Settings(std::string fileName, int verbosityLevel)
                                                       Form("(TMath::Sqrt((%f+%f*x+%f*x*x+%f*x*x*x)))/(2.*TMath::Sqrt(2.*TMath::Log(2.)))",offset, linear, quadratic, cubic),0.,100000.));
             fThreshold[1050][detector][crystal] = env.GetValue(Form("Griffin.BGO.Back.%d.%d.Threshold.keV",detector,crystal),10.);
             fThresholdWidth[1050][detector][crystal] = env.GetValue(Form("Griffin.BGO.Back.%d.%d.ThresholdWidth.keV",detector,crystal),2.);
+            fTimeWindow[1050][detector][crystal] = env.GetValue(Form("Griffin.BGO.Back.%d.%d.TimeWindow.sec",detector,crystal),0.);
         }
     }
 
@@ -169,6 +205,20 @@ Settings::Settings(std::string fileName, int verbosityLevel)
                                                   Form("(TMath::Sqrt((%f+%f*x+%f*x*x+%f*x*x*x)))/(2.*TMath::Sqrt(2.*TMath::Log(2.)))",offset, linear, quadratic, cubic),0.,100000.));
         fThreshold[2000][detector][0] = env.GetValue(Form("LaBr3.%d.Threshold.keV",detector),10.);
         fThresholdWidth[2000][detector][0] = env.GetValue(Form("LaBr3.%d.ThresholdWidth.keV",detector),2.);
+        fTimeWindow[2000][detector][0] = env.GetValue(Form("LaBr3.%d.TimeWindow.sec",detector),0.);
+    }
+
+    // Sceptar
+    for(int detector = 0; detector < 20; ++detector) {
+        offset = env.GetValue(Form("Sceptar.%d.Resolution.Offset",detector),0.0);
+        linear = env.GetValue(Form("Sceptar.%d.Resolution.Linear",detector),0.0);
+        quadratic = env.GetValue(Form("Sceptar.%d.Resolution.Quadratic",detector),0.0);
+        cubic = env.GetValue(Form("Sceptar.%d.Resolution.Cubic",detector),0.0);
+        fResolution[5000][detector].push_back(TF1(Form("Sceptar.%d.Resolution",detector),
+                                                  Form("(TMath::Sqrt((%f+%f*x+%f*x*x+%f*x*x*x)))/(2.*TMath::Sqrt(2.*TMath::Log(2.)))",offset, linear, quadratic, cubic),0.,100000.));
+        fThreshold[5000][detector][0] = env.GetValue(Form("Sceptar.%d.Threshold.keV",detector),0.0);
+        fThresholdWidth[5000][detector][0] = env.GetValue(Form("Sceptar.%d.ThresholdWidth.keV",detector),0.0);
+        fTimeWindow[5000][detector][0] = env.GetValue(Form("Sceptar.%d.TimeWindow.sec",detector),0.0);
     }
 
     // EightPi
@@ -181,6 +231,7 @@ Settings::Settings(std::string fileName, int verbosityLevel)
                                                   Form("(TMath::Sqrt((%f+%f*x+%f*x*x+%f*x*x*x)))/(2.*TMath::Sqrt(2.*TMath::Log(2.)))",offset, linear, quadratic, cubic),0.,100000.));
         fThreshold[6000][detector][0] = env.GetValue(Form("EightPi.%d.Threshold.keV",detector),10.);
         fThresholdWidth[6000][detector][0] = env.GetValue(Form("EightPi.%d.ThresholdWidth.keV",detector),2.);
+        fTimeWindow[6000][detector][0] = env.GetValue(Form("EightPi.%d.TimeWindow.sec",detector),0.);
 
         offset = env.GetValue(Form("EightPi.BGO.%d.Resolution.Offset",detector),1.100);
         linear = env.GetValue(Form("EightPi.BGO.%d.Resolution.Linear",detector),0.00183744);
@@ -190,6 +241,7 @@ Settings::Settings(std::string fileName, int verbosityLevel)
                                                   Form("(TMath::Sqrt((%f+%f*x+%f*x*x+%f*x*x*x)))/(2.*TMath::Sqrt(2.*TMath::Log(2.)))",offset, linear, quadratic, cubic),0.,100000.));
         fThreshold[6010][detector][0] = env.GetValue(Form("EightPi.BGO.%d.Threshold.keV",detector),10.);
         fThresholdWidth[6010][detector][0] = env.GetValue(Form("EightPi.BGO.%d.ThresholdWidth.keV",detector),2.);
+        fTimeWindow[6010][detector][0] = env.GetValue(Form("EightPi.BGO.%d.TimeWindow.sec",detector),0.);
 
         offset = env.GetValue(Form("EightPi.BGO.%d.Resolution.Offset",detector),1.100);
         linear = env.GetValue(Form("EightPi.BGO.%d.Resolution.Linear",detector),0.00183744);
@@ -199,6 +251,7 @@ Settings::Settings(std::string fileName, int verbosityLevel)
                                                   Form("(TMath::Sqrt((%f+%f*x+%f*x*x+%f*x*x*x)))/(2.*TMath::Sqrt(2.*TMath::Log(2.)))",offset, linear, quadratic, cubic),0.,100000.));
         fThreshold[6020][detector][0] = env.GetValue(Form("EightPi.BGO.%d.Threshold.keV",detector),10.);
         fThresholdWidth[6020][detector][0] = env.GetValue(Form("EightPi.BGO.%d.ThresholdWidth.keV",detector),2.);
+        fTimeWindow[6020][detector][0] = env.GetValue(Form("EightPi.BGO.%d.TimeWindow.sec",detector),0.);
 
         offset = env.GetValue(Form("EightPi.BGO.%d.Resolution.Offset",detector),1.100);
         linear = env.GetValue(Form("EightPi.BGO.%d.Resolution.Linear",detector),0.00183744);
@@ -208,6 +261,7 @@ Settings::Settings(std::string fileName, int verbosityLevel)
                                                   Form("(TMath::Sqrt((%f+%f*x+%f*x*x+%f*x*x*x)))/(2.*TMath::Sqrt(2.*TMath::Log(2.)))",offset, linear, quadratic, cubic),0.,100000.));
         fThreshold[6030][detector][0] = env.GetValue(Form("EightPi.BGO.%d.Threshold.keV",detector),10.);
         fThresholdWidth[6030][detector][0] = env.GetValue(Form("EightPi.BGO.%d.ThresholdWidth.keV",detector),2.);
+        fTimeWindow[6030][detector][0] = env.GetValue(Form("EightPi.BGO.%d.TimeWindow.sec",detector),0.);
     }
 
     // DESCANT
@@ -220,6 +274,7 @@ Settings::Settings(std::string fileName, int verbosityLevel)
                                                   Form("(TMath::Sqrt((%f+%f*x+%f*x*x+%f*x*x*x)))/(2.*TMath::Sqrt(2.*TMath::Log(2.)))",offset, linear, quadratic, cubic),0.,100000.));
         fThreshold[8010][detector][0] = env.GetValue(Form("Descant.Blue.%d.Threshold.keV",detector),0.);
         fThresholdWidth[8010][detector][0] = env.GetValue(Form("Descant.Blue.%d.ThresholdWidth.keV",detector),0.);
+        fTimeWindow[8010][detector][0] = env.GetValue(Form("Descant.Blue.%d.TimeWindow.sec",detector),0.);
     }
     for(int detector = 0; detector < 10; ++detector) {
         offset = env.GetValue(Form("Descant.Green.%d.Resolution.Offset",detector),0.0);
@@ -230,6 +285,7 @@ Settings::Settings(std::string fileName, int verbosityLevel)
                                                   Form("(TMath::Sqrt((%f+%f*x+%f*x*x+%f*x*x*x)))/(2.*TMath::Sqrt(2.*TMath::Log(2.)))",offset, linear, quadratic, cubic),0.,100000.));
         fThreshold[8020][detector][0] = env.GetValue(Form("Descant.Green.%d.Threshold.keV",detector),0.);
         fThresholdWidth[8020][detector][0] = env.GetValue(Form("Descant.Green.%d.ThresholdWidth.keV",detector),0.);
+        fTimeWindow[8020][detector][0] = env.GetValue(Form("Descant.Green.%d.TimeWindow.sec",detector),0.);
     }
     for(int detector = 0; detector < 15; ++detector) {
         offset = env.GetValue(Form("Descant.Red.%d.Resolution.Offset",detector),0.0);
@@ -240,6 +296,7 @@ Settings::Settings(std::string fileName, int verbosityLevel)
                                                   Form("(TMath::Sqrt((%f+%f*x+%f*x*x+%f*x*x*x)))/(2.*TMath::Sqrt(2.*TMath::Log(2.)))",offset, linear, quadratic, cubic),0.,100000.));
         fThreshold[8030][detector][0] = env.GetValue(Form("Descant.Red.%d.Threshold.keV",detector),0.);
         fThresholdWidth[8030][detector][0] = env.GetValue(Form("Descant.Red.%d.ThresholdWidth.keV",detector),0.);
+        fTimeWindow[8030][detector][0] = env.GetValue(Form("Descant.Red.%d.TimeWindow.sec",detector),0.);
     }
     for(int detector = 0; detector < 20; ++detector) {
         offset = env.GetValue(Form("Descant.White.%d.Resolution.Offset",detector),0.0);
@@ -250,6 +307,7 @@ Settings::Settings(std::string fileName, int verbosityLevel)
                                                   Form("(TMath::Sqrt((%f+%f*x+%f*x*x+%f*x*x*x)))/(2.*TMath::Sqrt(2.*TMath::Log(2.)))",offset, linear, quadratic, cubic),0.,100000.));
         fThreshold[8040][detector][0] = env.GetValue(Form("Descant.White.%d.Threshold.keV",detector),0.);
         fThresholdWidth[8040][detector][0] = env.GetValue(Form("Descant.White.%d.ThresholdWidth.keV",detector),0.);
+        fTimeWindow[8040][detector][0] = env.GetValue(Form("Descant.White.%d.TimeWindow.sec",detector),0.);
     }
     for(int detector = 0; detector < 10; ++detector) {
         offset = env.GetValue(Form("Descant.Yellow.%d.Resolution.Offset",detector),0.0);
@@ -260,6 +318,20 @@ Settings::Settings(std::string fileName, int verbosityLevel)
                                                   Form("(TMath::Sqrt((%f+%f*x+%f*x*x+%f*x*x*x)))/(2.*TMath::Sqrt(2.*TMath::Log(2.)))",offset, linear, quadratic, cubic),0.,100000.));
         fThreshold[8050][detector][0] = env.GetValue(Form("Descant.Yellow.%d.Threshold.keV",detector),0.);
         fThresholdWidth[8050][detector][0] = env.GetValue(Form("Descant.Yellow.%d.ThresholdWidth.keV",detector),0.);
+        fTimeWindow[8050][detector][0] = env.GetValue(Form("Descant.Yellow.%d.TimeWindow.sec",detector),0.);
+    }
+
+    // Paces
+    for(int detector = 0; detector < 5; ++detector) {
+        offset = env.GetValue(Form("Paces.%d.Resolution.Offset",detector),0.0);
+        linear = env.GetValue(Form("Paces.%d.Resolution.Linear",detector),0.0);
+        quadratic = env.GetValue(Form("Paces.%d.Resolution.Quadratic",detector),0.0);
+        cubic = env.GetValue(Form("Paces.%d.Resolution.Cubic",detector),0.0);
+        fResolution[9000][detector].push_back(TF1(Form("Paces.%d.Resolution",detector),
+                                                  Form("(TMath::Sqrt((%f+%f*x+%f*x*x+%f*x*x*x)))/(2.*TMath::Sqrt(2.*TMath::Log(2.)))",offset, linear, quadratic, cubic),0.,100000.));
+        fThreshold[9000][detector][0] = env.GetValue(Form("Paces.%d.Threshold.keV",detector),0.0);
+        fThresholdWidth[9000][detector][0] = env.GetValue(Form("Paces.%d.ThresholdWidth.keV",detector),0.0);
+        fTimeWindow[9000][detector][0] = env.GetValue(Form("Paces.%d.TimeWindow.sec",detector),0.0);
     }
 
     fNofBins["Statistics"] = env.GetValue("Histogram.Statistics.NofBins",64);
@@ -281,5 +353,13 @@ Settings::Settings(std::string fileName, int verbosityLevel)
     fNofBins["Griffin3D"] = env.GetValue("Histogram.3D.Griffin.NofBins",500);
     fRangeLow["Griffin3D"] = env.GetValue("Histogram.3D.Griffin.RangeLow.keV",0.5);
     fRangeHigh["Griffin3D"] = env.GetValue("Histogram.3D.Griffin.RangeHigh.keV",500.5);
+
+    fNofBins["Descant1D"] = env.GetValue("Histogram.1D.Descant.NofBins",10000);
+    fRangeLow["Descant1D"] = env.GetValue("Histogram.1D.Descant.RangeLow.keV",0.5);
+    fRangeHigh["Descant1D"] = env.GetValue("Histogram.1D.Descant.RangeHigh.keV",10000.5);
+
+    fNofBins["0RES_Descant1D"] = env.GetValue("Histogram.1D.Descant.NofBins",10000);
+    fRangeLow["0RES_Descant1D"] = env.GetValue("Histogram.1D.Descant.RangeLow.keV",0.5);
+    fRangeHigh["0RES_Descant1D"] = env.GetValue("Histogram.1D.Descant.RangeHigh.keV",10000.5);
 
 }

--- a/Settings.hh
+++ b/Settings.hh
@@ -12,6 +12,10 @@ public:
     Settings(std::string, int);
     ~Settings(){};
 
+    std::string NtupleName() {
+        return fNtupleName;
+    }
+
     int VerbosityLevel() {
         return fVerbosityLevel;
     }
@@ -74,6 +78,12 @@ public:
         }
         return 0.;
     }
+    double TimeWindow(int systemID, int detectorID, int crystalID) {
+        if(fTimeWindow.find(systemID) != fTimeWindow.end()) {
+            return fTimeWindow[systemID].at(detectorID).at(crystalID);
+        }
+        return 0.;
+    }
 
     int NofBins(std::string directoryName) {
         if(fNofBins.find(directoryName) != fNofBins.end()) {
@@ -95,6 +105,8 @@ public:
     }
 
 private:
+    std::string fNtupleName;
+
     int fVerbosityLevel;
     int fBufferSize;
     int fSortNumberOfEvents;
@@ -112,6 +124,7 @@ private:
     std::map<int,std::vector<std::vector<TF1> > > fResolution;
     std::map<int,std::vector<std::vector<double> > > fThreshold;
     std::map<int,std::vector<std::vector<double> > > fThresholdWidth;
+    std::map<int,std::vector<std::vector<double> > > fTimeWindow;
 
     std::map<std::string,int> fNofBins;
     std::map<std::string,double> fRangeLow;


### PR DESCRIPTION
Added option in the Settings file for a different ntuple name in the
input root file. The default is still what Geant4 outputs. Also methods
that check that all the "crystal" hits are unique, that is, they have
different crystal and detector IDs. If they have the same crystal and
detector IDs, then we sum the energies together. Normally the Geant4
simulation would sum energy deposits on the same volume, but if we ran
the code in "step mode", or if we merged two ntuples together, this
would not be true. These methods check and will do what "hit mode" in
Geant4 normally does for us!
