### PR TITLE
Removing the DescantNeutronDiscrimination "hack"

### DIFF
--- a/Converter.cc
+++ b/Converter.cc
@@ -1442,30 +1442,20 @@ bool Converter::Run() {
                         fEightPiBgoDetector->push_back(Detector(fEventNumber, fDetNumber, fCryNumber, fDepEnergy, smearedEnergy, TVector3(fPosx,fPosy,fPosz), fTime));
                         break;
                     case 8010:
-                        if(DescantNeutronDiscrimination() ) {
-                            fDescantBlueDetector->push_back(Detector(fEventNumber, fDetNumber, fCryNumber, fDepEnergy, smearedEnergy, TVector3(fPosx,fPosy,fPosz), fTime));
-                            break;
-                        }
+                        fDescantBlueDetector->push_back(Detector(fEventNumber, fDetNumber, fCryNumber, fDepEnergy, smearedEnergy, TVector3(fPosx,fPosy,fPosz), fTime));
+                         break;
                     case 8020:
-                        if(DescantNeutronDiscrimination() ) {
-                            fDescantGreenDetector->push_back(Detector(fEventNumber, fDetNumber, fCryNumber, fDepEnergy, smearedEnergy, TVector3(fPosx,fPosy,fPosz), fTime));
-                            break;
-                        }
+                        fDescantGreenDetector->push_back(Detector(fEventNumber, fDetNumber, fCryNumber, fDepEnergy, smearedEnergy, TVector3(fPosx,fPosy,fPosz), fTime));
+                        break;
                     case 8030:
-                        if(DescantNeutronDiscrimination() ) {
-                            fDescantRedDetector->push_back(Detector(fEventNumber, fDetNumber, fCryNumber, fDepEnergy, smearedEnergy, TVector3(fPosx,fPosy,fPosz), fTime));
-                            break;
-                        }
+                        fDescantRedDetector->push_back(Detector(fEventNumber, fDetNumber, fCryNumber, fDepEnergy, smearedEnergy, TVector3(fPosx,fPosy,fPosz), fTime));
+                        break;
                     case 8040:
-                        if(DescantNeutronDiscrimination() ) {
-                            fDescantWhiteDetector->push_back(Detector(fEventNumber, fDetNumber, fCryNumber, fDepEnergy, smearedEnergy, TVector3(fPosx,fPosy,fPosz), fTime));
-                            break;
-                        }
+                        fDescantWhiteDetector->push_back(Detector(fEventNumber, fDetNumber, fCryNumber, fDepEnergy, smearedEnergy, TVector3(fPosx,fPosy,fPosz), fTime));
+                        break;
                     case 8050:
-                        if(DescantNeutronDiscrimination() ) {
-                            fDescantYellowDetector->push_back(Detector(fEventNumber, fDetNumber, fCryNumber, fDepEnergy, smearedEnergy, TVector3(fPosx,fPosy,fPosz), fTime));
-                            break;
-                        }
+                        fDescantYellowDetector->push_back(Detector(fEventNumber, fDetNumber, fCryNumber, fDepEnergy, smearedEnergy, TVector3(fPosx,fPosy,fPosz), fTime));
+                        break;
                     case 9000:
                         fPacesDetector->push_back(Detector(fEventNumber, fDetNumber, fCryNumber, fDepEnergy, smearedEnergy, TVector3(fPosx,fPosy,fPosz), fTime));
                         break;


### PR DESCRIPTION
The DescantNeutronDiscrimination method screws up the switch statement.
In the case the particle was not a neutron the if statement is not
satisfied, and descends into the next case. This
DescantNeutronDiscrimination method, was a temporary hack anyway, it
reality we would like to look at the DESCANT spectrum to determine the
particle type.
