### PR TITLE
Using ```root-config --cflags``` instead of hard-coded c++ standard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,4 +81,4 @@ tar:
 # -------------------- clean --------------------
 
 clean:
-	rm  -f $(NAME) lib$(NAME).so *.o $(NAME)Dictionary.cc $(NAME)Dictionary.h
+	rm  -f $(NAME) lib$(NAME).so *.o $(NAME)Dictionary.cc $(NAME)Dictionary.h $(NAME)Dictionary_rdict.pcm

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ NAME		   = NTuple
 LIB_DIR 	   = $(HOME)/lib
 
 ROOTLIBS    := $(shell root-config --libs)
+ROOTFLAGS   := $(shell root-config --cflags)
 ROOTINC     := -I$(shell root-config --incdir)
 
 COMM_DIR 	= $(HOME)/CommandLineInterface
@@ -23,8 +24,8 @@ LIBRARIES	= CommandLineInterface Utilities
 
 CC		      = gcc
 CXX         = g++
-CPPFLAGS 	= $(ROOTINC) $(INCLUDES) -fPIC
-CXXFLAGS	   = -std=gnu++0x -pedantic -Wall -Wno-long-long -g -O3
+CPPFLAGS 	= $(ROOTINC) $(INCLUDES)
+CXXFLAGS	   = $(ROOTFLAGS) -pedantic -Wall -Wno-long-long -g -O3
 
 LDFLAGS		= -g -fPIC
 

--- a/Settings.cc
+++ b/Settings.cc
@@ -323,6 +323,14 @@ Settings::Settings(std::string fileName, int verbosityLevel)
         fTimeWindow[8050][detector][0] = env.GetValue(Form("Descant.Yellow.%d.TimeWindow.sec",detector),0.);
     }
 
+	 //testcan
+	 double fanoFactor = env.GetValue("Testcan.Resolution.FanoFactor",20.);
+	 fResolution[8500][0].push_back(TF1("Testcan.Resolution",Form("%f*TMath::Sqrt(x)",fanoFactor), 0., 100000.));
+	 fThreshold[8500][0][0] = env.GetValue("Testcan.Threshold.keV",0.);
+	 fThresholdWidth[8500][0][0] = env.GetValue("Testcan.ThresholdWidth.keV",0.);
+	 fTimeWindow[8500][0][0] = env.GetValue("Testcan.TimeWindow.sec",0.);
+
+
     // Paces
     for(int detector = 0; detector < 5; ++detector) {
         offset = env.GetValue(Form("Paces.%d.Resolution.Offset",detector),0.0);


### PR DESCRIPTION
This should address issue #23. Also removed the superfluous ```-fPIC``` from the CPPFLAGS.